### PR TITLE
Change in the .dot file label generation.

### DIFF
--- a/Tests/Transform/Vertex/ClassVertexTest.php
+++ b/Tests/Transform/Vertex/ClassVertexTest.php
@@ -7,6 +7,8 @@
 namespace Trismegiste\Mondrian\Tests\Transform\Vertex;
 
 use Trismegiste\Mondrian\Transform\Vertex\ClassVertex;
+use Trismegiste\Mondrian\Transform\Vertex\ImplVertex;
+use Trismegiste\Mondrian\Transform\Vertex\StaticAnalysis;
 
 /**
  * ClassVertexTest is an class vertex
@@ -25,7 +27,7 @@ class ClassVertexTest extends \PHPUnit_Framework_TestCase
     {
         $vertex = new ClassVertex('Full\Qualified\Class\Name\Sample');
         $attr = $vertex->getAttribute();
-        $this->assertEquals("FQCN\nSample", $attr['label']);
+        $this->assertEquals("FQCN".StaticAnalysis::LABEL_DELIMITER."Sample", $attr['label']);
     }
 
 }

--- a/Tests/Transform/Vertex/InterfaceVertexTest.php
+++ b/Tests/Transform/Vertex/InterfaceVertexTest.php
@@ -7,6 +7,7 @@
 namespace Trismegiste\Mondrian\Tests\Transform\Vertex;
 
 use Trismegiste\Mondrian\Transform\Vertex\InterfaceVertex;
+use Trismegiste\Mondrian\Transform\Vertex\StaticAnalysis;
 
 /**
  * InterfaceVertexTest is an interface vertex
@@ -25,7 +26,7 @@ class InterfaceVertexTest extends \PHPUnit_Framework_TestCase
     {
         $vertex = new InterfaceVertex('Full\Qualified\Class\Name\Sample');
         $attr = $vertex->getAttribute();
-        $this->assertEquals("FQCN\nSample", $attr['label']);
+        $this->assertEquals("FQCN".StaticAnalysis::LABEL_DELIMITER."Sample", $attr['label']);
     }
 
 }

--- a/Transform/Vertex/ImplVertex.php
+++ b/Transform/Vertex/ImplVertex.php
@@ -17,7 +17,7 @@ class ImplVertex extends StaticAnalysis
     {
         preg_match('#([^\\\\]+)::([^:]+)$#', $this->name, $capt);
         $default = array('shape' => 'rectangle', 'style' => 'filled',
-            'label' => $capt[1] . "\n" . $capt[2]);
+            'label' => $capt[1] . self::LABEL_DELIMITER . $capt[2]);
 
         return $default;
     }

--- a/Transform/Vertex/StaticAnalysis.php
+++ b/Transform/Vertex/StaticAnalysis.php
@@ -14,6 +14,8 @@ use Trismegiste\Mondrian\Graph\Vertex;
 abstract class StaticAnalysis extends Vertex implements Vizable, MetaInterface
 {
 
+    const LABEL_DELIMITER  = '\n';
+
     protected $metadata = array();
 
     public function getMeta($key)
@@ -59,7 +61,7 @@ abstract class StaticAnalysis extends Vertex implements Vizable, MetaInterface
             $prefix .= $itm[0];
         }
         if (!empty($prefix)) {
-            $prefix .= "\n";
+            $prefix .= self::LABEL_DELIMITER;
         }
 
         return $prefix . $short;


### PR DESCRIPTION
Instead of new line characters it delimits the lables with "->" and "-->>" strings.

The reason I did it because the graphviz did contain only the first line of the label.
